### PR TITLE
Add option for custom DNS resolution logic

### DIFF
--- a/src/HttpToSocks5Proxy/Dns/DefaultDnsResolver.cs
+++ b/src/HttpToSocks5Proxy/Dns/DefaultDnsResolver.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace MihaZupan.Dns
+{
+    internal class DefaultDnsResolver : IDnsResolver
+    {
+        public IPAddress TryResolve(string hostname)
+        {
+            IPAddress result = null;
+
+            if (IPAddress.TryParse(hostname, out var address))
+            {
+                return address;
+            }
+
+            try
+            {
+                result = System.Net.Dns.GetHostAddresses(hostname).FirstOrDefault();
+            }
+            catch (SocketException)
+            {
+                // ignore
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/HttpToSocks5Proxy/Dns/IDnsResolver.cs
+++ b/src/HttpToSocks5Proxy/Dns/IDnsResolver.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace MihaZupan.Dns
+{
+    public interface IDnsResolver
+    {
+       IPAddress TryResolve(string hostname);
+    }
+}

--- a/src/HttpToSocks5Proxy/Helpers.cs
+++ b/src/HttpToSocks5Proxy/Helpers.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using MihaZupan.Dns;
 
 namespace MihaZupan
 {
@@ -43,12 +44,6 @@ namespace MihaZupan
             }
 
             return false;
-        }
-
-        public static IPAddress Resolve(this string hostname)
-        {
-            if (IPAddress.TryParse(hostname, out IPAddress hostIP)) return hostIP;
-            return Dns.GetHostAddresses(hostname)[0];
         }
 
         private static readonly string[] HopByHopHeaders = new string[]

--- a/src/HttpToSocks5Proxy/SocketRelay.cs
+++ b/src/HttpToSocks5Proxy/SocketRelay.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Sockets;
+﻿using System;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace MihaZupan
@@ -126,8 +127,8 @@ namespace MihaZupan
             relayOne.Other = relayTwo;
             relayTwo.Other = relayOne;
 
-            Task.Run(relayOne.Process);
-            Task.Run(relayTwo.Process);
+            Task.Run(new Action(relayOne.Process));
+            Task.Run(new Action(relayTwo.Process));
         }
     }
 }

--- a/test/HttpToSocks5Proxy.Tests/HttpToSocks5Proxy.Tests.csproj
+++ b/test/HttpToSocks5Proxy.Tests/HttpToSocks5Proxy.Tests.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/HttpToSocks5Proxy.Tests/Program.cs
+++ b/test/HttpToSocks5Proxy.Tests/Program.cs
@@ -13,13 +13,11 @@ namespace Socks5Proxy.Tests
                 new ProxyInfo("proxy-server.com", 1080),
             });
             var handler = new HttpClientHandler { Proxy = proxy };
-            HttpClient httpClient = new HttpClient(handler, true);
+            var httpClient = new HttpClient(handler, true);
 
-            var result = await httpClient.SendAsync(
-                new HttpRequestMessage(HttpMethod.Get, "https://httpbin.org/ip"));
+            var result = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://httpbin.org/ip"));
 
             result.EnsureSuccessStatusCode();
-
             Console.WriteLine("HTTPS GET: " + await result.Content.ReadAsStringAsync());
 
             Console.ReadLine();

--- a/test/HttpToSocks5Proxy.Tests/Program.cs
+++ b/test/HttpToSocks5Proxy.Tests/Program.cs
@@ -9,16 +9,18 @@ namespace Socks5Proxy.Tests
     {
         static async Task Main()
         {
-            var proxy = new HttpToSocks5Proxy(new[] {
-                new ProxyInfo("proxy-server.com", 1080),
-            });
+            var proxy = new HttpToSocks5Proxy(new[] { new ProxyInfo("proxy-server.com", 1080) });
             var handler = new HttpClientHandler { Proxy = proxy };
             var httpClient = new HttpClient(handler, true);
 
             var result = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://httpbin.org/ip"));
-
             result.EnsureSuccessStatusCode();
-            Console.WriteLine("HTTPS GET: " + await result.Content.ReadAsStringAsync());
+            Console.WriteLine("#1 HTTPS GET: " + await result.Content.ReadAsStringAsync());
+
+            proxy.ResolveHostnamesLocally = true;
+            result = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://httpbin.org/ip"));
+            result.EnsureSuccessStatusCode();
+            Console.WriteLine("#2 HTTPS GET: " + await result.Content.ReadAsStringAsync());
 
             Console.ReadLine();
         }


### PR DESCRIPTION
This pull request makes it possible to use a custom DNS resolve logic by adding a new IDnsResolver interface and a default implementation that uses the built-in DNS resolution provided by the OS.

**Why?**
By providing a custom implementation of this interface the library users can specify a fix DNS server to use during the proxy communication.

**How?**
The changes are backward compatible, if there is no IDnsResolver argument provided in the constructor, the original DNS resolution logic will be used.

Dummy implementation:
```
public class CustomDnsResolver : IDnsResolver
{
    public IPAddress TryResolve(string hostname)
    {
        if (IPAddress.TryParse(hostname, out var address))
        {
            return address;
        }

        var client = new DnsClient("1.1.1.1"); // dns client from a nuget package
        return client.Lookup(hostname);
    }
}
```

Example usage:
```
var proxy = new HttpToSocks5Proxy(new[] { new ProxyInfo("proxy-server.com", 1080) }, 0, new CustomDnsResolver());
```